### PR TITLE
Update definition.ex

### DIFF
--- a/lib/memento/table/definition.ex
+++ b/lib/memento/table/definition.ex
@@ -156,6 +156,10 @@ defmodule Memento.Table.Definition do
           # Indices aren't atoms
           !Enum.all?(index, &is_atom/1) ->
             "Invalid index list specified"
+          
+          # Autoincrement isn't a boolean
+          !is_boolean(auto) ->
+             "Invalid autoincrement parameter specified"
 
           # Table type is not one of allowed
           !Enum.member?(@allowed_types, type) ->


### PR DESCRIPTION
# Motivation

I'm getting a compilation warning
```
warning: variable "auto" is unused (if the variable is not meant to be used, prefix it with an underscore)
  lib/memento/table/definition.ex:137
``
