### PR TITLE
Fix deprecated __info__ function call without parens

### DIFF
--- a/lib/memento/table/definition.ex
+++ b/lib/memento/table/definition.ex
@@ -192,7 +192,7 @@ defmodule Memento.Table.Definition do
   @doc "Raise error if a given module is not a valid Memento Table"
   @spec validate_table!(module) :: :ok | no_return
   def validate_table!(module) do
-    Memento.Table = module.__info__.meta
+    Memento.Table = module.__info__().meta
     :ok
   rescue
     _ ->


### PR DESCRIPTION
Elixir 1.17.0 deprecates calling functions without parens.