### PR TITLE
Fix deprecated function calls without parens

### DIFF
--- a/lib/memento/query/query.ex
+++ b/lib/memento/query/query.ex
@@ -276,7 +276,7 @@ defmodule Memento.Query do
   """
   @spec all(Table.name, options) :: list(Table.record)
   def all(table, opts \\ []) do
-    pattern = table.__info__.query_base
+    pattern = table.__info__().query_base
     lock = Keyword.get(opts, :lock, :read)
 
     :match_object
@@ -420,8 +420,10 @@ defmodule Memento.Query do
   @result [:"$_"]
   @spec select(Table.name, list(tuple) | tuple, options) :: list(Table.record)
   def select(table, guards, opts \\ []) do
-    attr_map   = table.__info__.query_map
-    match_head = table.__info__.query_base
+    info = table.__info__()
+
+    attr_map   = info.query_map
+    match_head = info.query_base
     guards     = Memento.Query.Spec.build(guards, attr_map)
 
     select_raw(table, [{ match_head, guards, @result }], opts)
@@ -491,7 +493,7 @@ defmodule Memento.Query do
   Return all records:
 
   ```
-  match_head = Movie.__info__.query_base
+  match_head = Movie.__info__().query_base
   result = [:"$_"]
   guards = []
 
@@ -674,8 +676,7 @@ defmodule Memento.Query do
 
   # Raises error if tuple size and no. of attributes is not equal
   defp validate_match_pattern!(table, pattern) do
-    same_size? =
-      (tuple_size(pattern) == table.__info__.size)
+    same_size? = (tuple_size(pattern) == table.__info__().size)
 
     unless same_size? do
       Memento.Error.raise(

--- a/test/memento/mnesia_test.exs
+++ b/test/memento/mnesia_test.exs
@@ -51,7 +51,7 @@ defmodule Memento.Tests.Mnesia do
   describe "#handle_result" do
     test "reraises specific erlang errors as elixir exceptions" do
       assert_raise(UndefinedFunctionError, ~r/is undefined/i, result_for(fn ->
-        RandomModule.undefined_fun
+        RandomModule.undefined_fun()
       end))
     end
 

--- a/test/memento/query/query_test.exs
+++ b/test/memento/query/query_test.exs
@@ -314,7 +314,7 @@ defmodule Memento.Tests.Query do
 
   describe "#select_raw" do
     @table Tables.Movie
-    @match_all [{ @table.__info__.query_base, [], [:"$_"] }]
+    @match_all [{ @table.__info__().query_base, [], [:"$_"] }]
 
     setup do
       Memento.Table.create(@table)
@@ -368,7 +368,7 @@ defmodule Memento.Tests.Query do
 
 
     test "Returns empty list when nothing matches and limit is non-nil" do
-      match_none = [{ @table.__info__.query_base, [{:==, :id, :invalid}], [:"$_"] }]
+      match_none = [{ @table.__info__().query_base, [{:==, :id, :invalid}], [:"$_"] }]
 
       Support.Mnesia.transaction fn ->
         assert [] = Query.select_raw(@table, match_none, limit: 5)


### PR DESCRIPTION
I found some more warnings regarding function calls without `()`, similar to #33.

```elixir
warning: using map.field notation (without parentheses) to invoke function MyApp.History.__info__() is deprecated, you must add parentheses instead: remote.function()
  (memento 0.3.2) lib/memento/query/query.ex:279: Memento.Query.all/2
  (elixir 1.17.1) src/elixir.erl:386: :elixir.eval_external_handler/3
  (mnesia 4.23.1) mnesia_tm.erl:889: :mnesia_tm.apply_fun/3
  (mnesia 4.23.1) mnesia_tm.erl:865: :mnesia_tm.execute_transaction/5
  (memento 0.3.2) lib/memento/transaction.ex:71: Memento.Transaction.execute/2

```