### PR TITLE
Fix CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,30 +14,28 @@ jobs:
     strategy:
       matrix:
         include:
-          - elixir: '1.8'
-            otp: '20'
-          - elixir: '1.8'
-            otp: '21'
-          - elixir: '1.9'
-            otp: '21'
-          - elixir: '1.9'
-            otp: '22'
-          - elixir: '1.10'
-            otp: '21.0'
-          - elixir: '1.10'
-            otp: '22.0'
-          - elixir: '1.11'
-            otp: '23.0'
+          - elixir: '1.14'
+            otp: '25.0'
+          - elixir: '1.15'
+            otp: '25.0'
+          - elixir: '1.15'
+            otp: '26.0'
+          - elixir: '1.16'
+            otp: '26.0'
+          - elixir: '1.17'
+            otp: '26.0'
+          - elixir: '1.17'
+            otp: '27.0'
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}
 
       - name: Restore dependencies cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: deps
           key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}


### PR DESCRIPTION
This PR is a try to fix the failing CI pipeline by using `ubuntu-18.04` for old Elixir/OTP versions and `ubuntu-latest` for new versions.

Fixes #36