### PR TITLE
Explicitly use a range step of -1

### DIFF
--- a/lib/memento/table/definition.ex
+++ b/lib/memento/table/definition.ex
@@ -42,7 +42,7 @@ defmodule Memento.Table.Definition do
     attributes =
       attributes
       |> Enum.count
-      |> Range.new(1)
+      |> Range.new(1, -1)
       |> Enum.reverse
       |> Enum.map(&:"$#{&1}")
 


### PR DESCRIPTION
This fixes a deprecation warning introduced in Elixir 1.18.0. Range.new/3 was added in Elixir 1.12.0 according to documentation, so should be safe to use with the versions declared to be supported by Memento.